### PR TITLE
Ignore success output

### DIFF
--- a/model-validation-track/process
+++ b/model-validation-track/process
@@ -5,6 +5,11 @@
 
 # $1: model
 # $2: benchmark after preprocessing
-sed -i 's/^[0-9]*\.[0-9]*\/[0-9]*.[0-9]*\t//g' $1
-PYTHONPATH="pysmt" python2 ModelValidator.py --smt2 $2 --model $1
+
+# remove the StarExec timing information from each line of the solver output
+sed 's/^[0-9]*\.[0-9]*\/[0-9]*.[0-9]*\t//g' "$1" | \
+# remove success response lines from solver output
+grep -v '^success$' > ./cleanSolverOutput.txt
+
+PYTHONPATH="pysmt" python2 ModelValidator.py --smt2 $2 --model ./cleanSolverOutput.txt
 


### PR DESCRIPTION
Filter out success outputs.  The SMT-LIB standard says that solvers should reply success to every statement, so the postprocessor shouldn't flag them as error.

The script no longer does inplace-editing but copies the results to a new file, similar to the unsat-core postprocessor.

We only filter out lines that say "success" in its own line without any other characters. This should work for all solvers we encountered so far.  I didn't want to go fancy and write an sexpr parser that is 100 % correct in filtering success outputs.