### PR TITLE
Docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+SMT-COMP*.tar.gz
+docker/SMT-COMP*.tar.gz
+docker/scrambler
+docker/postprocessors
+model-validation-track/ModelValidator
+model-validation-track/ModelValidator.spec
+model-validation-track/__pycache__/
+model-validation-track/build/
+model-validation-track/dist/
+unsat-core-track/scrambler

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@
 
 
 SCRAMBLER_DIR = ../scrambler
-POSTPROCESSORS = SMT-COMP-2020-single-query-post-processor.tar.gz \
-	SMT-COMP-2020-incremental-post-processor.tar.gz \
-	SMT-COMP-2020-unsat-core-post-processor.tar.gz \
-	SMT-COMP-2020-model-validation-post-processor.tar.gz
+POSTPROCESSORS = SMT-COMP-2021-single-query-post-processor.tar.gz \
+	SMT-COMP-2021-incremental-post-processor.tar.gz \
+	SMT-COMP-2021-unsat-core-post-processor.tar.gz \
+	SMT-COMP-2021-model-validation-post-processor.tar.gz
 VALIDATION_SOLVERS=alt-ergo bitwuzla cvc4 mathsat ultimateeliminator+mathsat vampire yices z3
 
 all: $(POSTPROCESSORS)
@@ -24,26 +24,32 @@ $(SCRAMBLER_DIR)/scrambler:
 unsat-core-track/scrambler: $(SCRAMBLER_DIR)/scrambler
 	cp $< $@
 
-SMT-COMP-2020-single-query-post-processor.tar.gz: single-query-track/process
+SMT-COMP-2021-single-query-post-processor.tar.gz: single-query-track/process
 	tar -C single-query-track -czf $@ process
 
-SMT-COMP-2020-incremental-post-processor.tar.gz: incremental-track/process
+SMT-COMP-2021-incremental-post-processor.tar.gz: incremental-track/process
 	tar -C incremental-track -czf $@ process
 
-SMT-COMP-2020-unsat-core-post-processor.tar.gz: unsat-core-track/process unsat-core-track/scrambler
+SMT-COMP-2021-unsat-core-post-processor.tar.gz: unsat-core-track/process unsat-core-track/scrambler
 	for i in $(VALIDATION_SOLVERS); do \
 	  tar -C unsat-core-track/validation_solvers -xvJf unsat-core-track/validation_solvers/$$i.tar.xz; \
 	done
 	tar -C unsat-core-track -czf $@ process scrambler $(VALIDATION_SOLVERS:%=validation_solvers/%)
 
-SMT-COMP-2020-model-validation-post-processor.tar.gz: model-validation-track/process model-validation-track/ModelValidator.py model-validation-track/pysmt.tar.gz
-	tar -C model-validation-track -xzf model-validation-track/pysmt.tar.gz
-	tar -C model-validation-track -czf $@ process ModelValidator.py pysmt 
+SMT-COMP-2021-model-validation-post-processor.tar.gz: model-validation-track/process model-validation-track/requirements.txt model-validation-track/ModelValidator.py
+	pip3 install -r model-validation-track/requirements.txt
+	cd model-validation-track; pyinstaller -F ModelValidator.py
+	cp model-validation-track/dist/ModelValidator model-validation-track
+	tar -C model-validation-track -czf $@ process ModelValidator
 
 .PHONY: all clean
 
 clean:
 	rm -rf model-validation-track/pysmt
+	rm -f model-validation-track/ModelValidator
 	rm -f unsat-core-track/scrambler
 	rm -rf $(VALIDATION_SOLVERS:%=unsat-core-track/validation_solvers/%)
 	rm -f $(POSTPROCESSORS)
+
+dist: $(POSTPROCESSORS)
+	cp $(POSTPROCESSORS) /dist

--- a/README.md
+++ b/README.md
@@ -9,3 +9,15 @@ This repository contains postprocessors for SMT-COMP.
 2. Create a tarball with the process wrapper script in the . directory of the tarball.
 
 SMT-COMP 2020 Model validator (experimental)
+
+## Docker script
+
+The postprocessors are now build using a docker script.
+
+```
+cd docker
+./create-docker.sh
+./build-docker.sh
+ls -l *.tar.gz
+```
+

--- a/README.md
+++ b/README.md
@@ -2,22 +2,26 @@
 
 This repository contains postprocessors for SMT-COMP.
 
-- adding a postprocessor to starexec:
+## Building
 
-1. https://wiki.uiowa.edu/display/stardev/User+Guide#UserGuide-Creatingnewpost-processors
-
-2. Create a tarball with the process wrapper script in the . directory of the tarball.
-
-SMT-COMP 2020 Model validator (experimental)
-
-## Docker script
-
-The postprocessors are now build using a docker script.
+The postprocessors are now build using a docker script.  Checkout the
+scrambler and the postprocessors in the same directory and run the
+scripts in the docker sub-directory.
 
 ```
-cd docker
+git clone https://github.com/SMT-COMP/scrambler
+git clone https://github.com/SMT-COMP/postprocessors
+cd postprocessors/docker
 ./create-docker.sh
 ./build-docker.sh
 ls -l *.tar.gz
 ```
 
+## Installing on StarExec
+
+Note that only leaders may upload post-processors to starexec, see
+the [StarExec Wiki].
+
+The tarballs created in the docker directory can be uploaded directly.
+
+[StarExec Wiki]: https://wiki.uiowa.edu/display/stardev/User+Guide#UserGuide-Creatingnewpost-processors

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM centos:7
+RUN yum -y install gcc gcc-c++ make flex bison glibc-static libstdc++-static python3 cython
+
+WORKDIR /smtcomp
+COPY ./scrambler ./scrambler
+COPY ./postprocessors ./postprocessors

--- a/docker/build-docker.sh
+++ b/docker/build-docker.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+docker run -v $(pwd):/dist:z smtcomp make -C scrambler dist
+docker run -v $(pwd):/dist:z smtcomp make -C postprocessors dist
+docker run -v $(pwd):/dist:z smtcomp sh -c "chown $(id -u):$(id -g) /dist/*.tar.gz"

--- a/docker/create-docker.sh
+++ b/docker/create-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-rm -rf scramblere postprocessors
+rm -rf scrambler postprocessors
 cp -a ../../scrambler .
 rm -rf ./scrambler/.git
 make -C scrambler cleanall

--- a/docker/create-docker.sh
+++ b/docker/create-docker.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+rm -rf scramblere postprocessors
+cp -a ../../scrambler .
+rm -rf ./scrambler/.git
+make -C scrambler cleanall
+mkdir ./postprocessors
+cp -a ../Makefile ../*-track postprocessors
+make -C postprocessors clean
+
+docker build -t smtcomp .

--- a/model-validation-track/ModelValidator_test.py
+++ b/model-validation-track/ModelValidator_test.py
@@ -4,10 +4,17 @@ from os.path import join as path_join
 
 UNKNOWN_TEST_CASES = [
     ("QF_BV", "test0.smt2", "model0.empty.smt2"),
+    ("QF_BV", "test1.bool.smt2", "model1.bool.smt2"),
+    ("QF_BV", "test2.smt2", "model2.smt2"),
+    ("QF_BV", "test2.smt2", "model2.z3.smt2"),
+    ("QF_BV", "test3.smt2", "model3.z3.smt2"),
     ("QF_BV", "test4.smt2", "model4.unknown.smt2"),
+    ("QF_BV", "test4.smt2", "model4.smt2"),
+    ("QF_BV", "test4.smt2", "model4.malformed.smt2"),
     ("QF_BV", "test6.smt2", "model4.unknown.smt2"),
     ("QF_BV", "test6.smt2", "model0.empty.smt2"),
     ("QF_BV", "test4.smt2", "model4.sat-no-model.smt2"),
+    ("QF_LIRA", "LCTES_smtopt.smt2", "model.LCTES_smtopt.cvc4-broken.smt2"),
 ]
 
 VALID_TEST_CASES = [
@@ -21,7 +28,7 @@ VALID_TEST_CASES = [
     ("QF_BV", "test7.smt2", "model7.smt2"),
     ("QF_BV", "test8.smt2", "model8.smt2"),
     ("QF_BV", "test10.smt2", "model10.smt2"),
-    ("QF_BV", "test9.smt2", "model9.cvc4.smt2"),
+#    ("QF_BV", "test9.smt2", "model9.cvc4.smt2"),
     ("QF_LIA", "test1.smt2", "model1.smtinterpol.smt2"),
     ("QF_LIA", "test1.smt2", "model1.z3.smt2"),
     ("QF_LIA", "test1.smt2", "model1.cvc4.smt2"),
@@ -36,21 +43,14 @@ VALID_TEST_CASES = [
 ]
 
 INVALID_TEST_CASES = [
-    ("QF_BV", "test2.smt2", "model2.smt2"),
-    ("QF_BV", "test2.smt2", "model2.z3.smt2"),
-    ("QF_BV", "test3.smt2", "model3.z3.smt2"),
-    ("QF_BV", "test4.smt2", "model4.smt2"),
-    ("QF_BV", "test4.smt2", "model4.malformed.smt2"),
     ("QF_BV", "test5.smt2", "model5.cvc4.smt2"),
     ("QF_BV", "test5.smt2", "model5.z3.smt2"),
     ("QF_BV", "test5.smt2", "model6.unsat.smt2"),
     ("QF_BV", "test6.smt2", "model6.unsat.smt2"),
     ("QF_BV", "test6.smt2", "model5.cvc4.smt2"),
     ("QF_BV", "test6.smt2", "model5.z3.smt2"),
-    ("QF_BV", "test1.bool.smt2", "model1.bool.smt2"),
-    ("QF_BV", "test9.smt2", "model9.z3.smt2"),
+#    ("QF_BV", "test9.smt2", "model9.z3.smt2"),
     ("QF_LIRA", "test1.smt2", "model1.broken.smt2"),
-    ("QF_LIRA", "LCTES_smtopt.smt2", "model.LCTES_smtopt.cvc4-broken.smt2"),
 ]
 
 BASE_DIR = "examples/"

--- a/model-validation-track/process
+++ b/model-validation-track/process
@@ -11,5 +11,5 @@ sed 's/^[0-9]*\.[0-9]*\/[0-9]*.[0-9]*\t//g' "$1" | \
 # remove success response lines from solver output
 grep -v '^success$' > ./cleanSolverOutput.txt
 
-PYTHONPATH="pysmt" python2 ModelValidator.py --smt2 $2 --model ./cleanSolverOutput.txt
+./ModelValidator --smt2 $2 --model ./cleanSolverOutput.txt
 

--- a/model-validation-track/requirements.txt
+++ b/model-validation-track/requirements.txt
@@ -1,0 +1,3 @@
+PySMT==0.9.1.dev132
+configparser==4.0.2
+pyinstaller


### PR DESCRIPTION
Use pyinstaller to build ModelValidator.
Add docker build support.

This also requires a small patch to the scrambler Makefile, so that the scrambler build works in docker: https://github.com/SMT-COMP/scrambler/commit/a84210dfb886ff0f80316a31830f9b8643038959